### PR TITLE
Autogenerate secret key if it's not set.

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,11 +1,12 @@
 import os
+import secrets
 basedir = os.path.abspath(os.path.dirname(__file__))
 
 class Config(object):
     SERVER_NAME = os.environ.get('BASE_URL')
     APPNAME = os.environ.get('APPNAME') or 'Glauth UI'
     ORGANISATION = os.environ.get('ORGANISATION') or 'Glauth UI - Team'
-    SECRET_KEY = os.environ.get('SECRET_KEY') or 'you-will-never-guess'
+    SECRET_KEY = os.environ.get("SECRET_KEY", secrets.token_hex(16))
     ADMIN_GROUP = os.environ.get('ADMIN_GROUP') or 'glauth_admin'
 
     # MAIL Config


### PR DESCRIPTION
In this example it's not stored in the DB. This means it changes every boot so any logged in users will be kicked out on reboot.