### PR TITLE
Replaced unixid with uid-/gidnumber (glauth v2.0)

### DIFF
--- a/app/adminview.py
+++ b/app/adminview.py
@@ -91,9 +91,9 @@ class UserView(MyModelView):
                          othergroups='Other Groups', 
                          is_active='Active',
                          mail='Email Address',
-                         unixid='UnixID')
+                         uidnumber='UIDNumber')
     # Configure columns in list view (order and which to show)
-    column_list = ('username', 'givenname', 'surname', 'mail', 'unixid', 'is_active', 'pgroup') #, 'othergroups')
+    column_list = ('username', 'givenname', 'surname', 'mail', 'uidnumber', 'is_active', 'pgroup') #, 'othergroups')
     # Configure columns that are editable in list view
     column_editable_list = ['username', 'mail', 'givenname', 'surname', 'is_active']
     # Configure columns that a searchable
@@ -101,7 +101,7 @@ class UserView(MyModelView):
     # Configure columns to exclude in list view
     column_exclude_list = ['password_hash']
     # Details View List
-    column_details_list = ('username', 'givenname', 'surname', 'mail', 'unixid', 'is_active', 'pgroup')
+    column_details_list = ('username', 'givenname', 'surname', 'mail', 'uidnumber', 'is_active', 'pgroup')
 
     # Configure colums to exclude in edit/create view
     form_excluded_columns = column_exclude_list
@@ -125,7 +125,7 @@ class UserView(MyModelView):
     )
 
     # Configure which form fields to show
-    form_columns = ('send_pw_reset_link', 'send_invite_link', 'username', 'password', 'givenname', 'surname', 'mail', 'unixid', 'is_active', 'pgroup', 'othergroups')
+    form_columns = ('send_pw_reset_link', 'send_invite_link', 'username', 'password', 'givenname', 'surname', 'mail', 'uidnumber', 'is_active', 'pgroup', 'othergroups')
 
     # Configure which columns are shown in detail view
     column_details_exclude_list = ['password_hash']
@@ -147,11 +147,11 @@ class UserView(MyModelView):
         # Add Password field description
         form.password.description = 'Leave empty if you want to autogenerate a password.'
 
-        default_unixid=5001
-        highest_user=User.query.order_by(User.unixid.desc()).limit(1).all()
+        default_uidnumber=5001
+        highest_user=User.query.order_by(User.uidnumber.desc()).limit(1).all()
         if highest_user:
-            default_unixid=highest_user[0].unixid+1
-        form.unixid.data=default_unixid
+            default_uidnumber=highest_user[0].uidnumber+1
+        form.uidnumber.data=default_uidnumber
         return form
     
     def edit_form(self, obj):
@@ -236,19 +236,19 @@ class GroupView(MyModelView):
                          name='Name',
                          description='Description',
                          primary='Primary Group', 
-                         unixid='UnixID',
+                         gidnumber='GIDNumber',
                          included_in='Included in Group(s)',
                          includes='Includes Group(s)')
     # Configure columns in list view (order and which to show)
-    column_list = ('name', 'unixid', 'primary', 'description')
+    column_list = ('name', 'gidnumber', 'primary', 'description')
     # Configure columns that are editable in list view
     column_editable_list = []
     # Configure columns that a searchable
-    column_searchable_list = ['name', 'unixid', 'primary', 'description']
+    column_searchable_list = ['name', 'gidnumber', 'primary', 'description']
     # Configure columns to exclude in list view
     #column_exclude_list = ['password_hash']
     
-    column_details_list = ('name', 'unixid', 'primary', 'description', 'includes')
+    column_details_list = ('name', 'gidnumber', 'primary', 'description', 'includes')
 
     # Sort by primary then name
     column_default_sort = [('primary', True), ('name', False)]
@@ -264,7 +264,7 @@ class GroupView(MyModelView):
     )
 
     # Configure which form fields to show
-    form_columns = ('name', 'unixid', 'primary', 'description', 'includes', 'included_in', 'p_users', 'o_users')
+    form_columns = ('name', 'gidnumber', 'primary', 'description', 'includes', 'included_in', 'p_users', 'o_users')
 
     # Configure which columns are shown in detail view
     column_details_exclude_list = ['password_hash']
@@ -283,11 +283,11 @@ class GroupView(MyModelView):
         delattr(form, 'included_in')
         delattr(form, 'p_users')
         delattr(form, 'o_users')
-        default_unixid=5500
-        highest_group=Group.query.order_by(Group.unixid.desc()).limit(1).all()
+        default_gidnumber=5500
+        highest_group=Group.query.order_by(Group.gidnumber.desc()).limit(1).all()
         if highest_group:
-            default_unixid=highest_group[0].unixid+1
-        form.unixid.data=default_unixid
+            default_gidnumber=highest_group[0].gidnumber+1
+        form.gidnumber.data=default_gidnumber
         return form
     
     def edit_form(self, obj):

--- a/app/glauth.py
+++ b/app/glauth.py
@@ -43,11 +43,11 @@ def create_glauth_config():
             new_config += "  sn = \"{}\"\n".format(user.surname)
         if user.mail:
             new_config += "  mail = \"{}\"\n".format(user.mail)
-        new_config += "  unixid = {}\n".format(user.unixid)
+        new_config += "  uidnumber = {}\n".format(user.uidnumber)
         new_config += "  primarygroup = {}\n".format(user.primarygroup)
         new_config += "  passsha256 = \"{}\"\n".format(user.password_hash)
         if len(user.othergroups) > 0:
-            new_config += "  otherGroups = [ {} ]\n".format(",".join(str(group.unixid) for group in user.othergroups))
+            new_config += "  otherGroups = [ {} ]\n".format(",".join(str(group.gidnumber) for group in user.othergroups))
         if not user.is_active:
             new_config += "  disabled = true\n"
         new_config += "\n"
@@ -56,10 +56,10 @@ def create_glauth_config():
     for group in groups:
         new_config += "[[groups]]\n"
         new_config += "  name = \"{}\"\n".format(group.name)
-        new_config += "  unixid = {}\n".format(group.unixid)
+        new_config += "  gidnumber = {}\n".format(group.gidnumber)
         # Need to count the query results as len() is not working here.
         if group.included_in.count() > 0:
-            new_config += "  includegroups = [ {} ]\n".format(",".join(str(group.unixid) for group in group.included_in))
+            new_config += "  includegroups = [ {} ]\n".format(",".join(str(group.gidnumber) for group in group.included_in))
         # Add Group description as comment
         if group.description != None:
             new_config += "  # {}\n".format(group.description)

--- a/app/routes.py
+++ b/app/routes.py
@@ -14,7 +14,7 @@ from ipaddress import ip_network, ip_address
 @app.route('/index')
 @login_required
 def index():
-    pgroup_name = Group.query.filter_by(unixid=current_user.primarygroup).first().name
+    pgroup_name = Group.query.filter_by(gidnumber=current_user.primarygroup).first().name
     #return render_template('index.html', title='Home', user=user)
     return render_template("index.html", title='Profile', primarygroup=pgroup_name)
 

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -31,8 +31,8 @@
             <td class="text-primary">{{ current_user.mail }}</td>
           </tr>
           <tr>
-            <th scope="row">UnixID</th>
-            <td class="text-danger">{{ current_user.unixid }}</td>
+            <th scope="row">UIDNumber</th>
+            <td class="text-danger">{{ current_user.uidnumber }}</td>
           </tr>
           <tr>
             <th scope="row">Groups</th>

--- a/migrations/versions/ea1b74e55123_test.py
+++ b/migrations/versions/ea1b74e55123_test.py
@@ -21,11 +21,11 @@ def upgrade():
     op.create_table('group',
     sa.Column('id', sa.Integer(), nullable=False),
     sa.Column('name', sa.String(length=20), nullable=False),
-    sa.Column('unixid', sa.Integer(), nullable=False),
+    sa.Column('gidnumber', sa.Integer(), nullable=False),
     sa.Column('primary', sa.Boolean(), nullable=False),
     sa.Column('description', sa.String(length=255), nullable=True),
     sa.PrimaryKeyConstraint('id'),
-    sa.UniqueConstraint('unixid')
+    sa.UniqueConstraint('gidnumber')
     )
     op.create_index(op.f('ix_group_name'), 'group', ['name'], unique=True)
     op.create_table('settings',
@@ -43,8 +43,8 @@ def upgrade():
     op.create_table('included_groups',
     sa.Column('include_id', sa.Integer(), nullable=True),
     sa.Column('included_in_id', sa.Integer(), nullable=True),
-    sa.ForeignKeyConstraint(['include_id'], ['group.unixid'], ),
-    sa.ForeignKeyConstraint(['included_in_id'], ['group.unixid'], )
+    sa.ForeignKeyConstraint(['include_id'], ['group.gidnumber'], ),
+    sa.ForeignKeyConstraint(['included_in_id'], ['group.gidnumber'], )
     )
     op.create_table('user',
     sa.Column('id', sa.Integer(), nullable=False),
@@ -52,21 +52,21 @@ def upgrade():
     sa.Column('mail', sa.String(length=50), nullable=True),
     sa.Column('givenname', sa.String(length=40), nullable=True),
     sa.Column('surname', sa.String(length=40), nullable=True),
-    sa.Column('unixid', sa.Integer(), nullable=False),
+    sa.Column('uidnumber', sa.Integer(), nullable=False),
     sa.Column('is_active', sa.Boolean(), nullable=False),
     sa.Column('password_hash', sa.String(length=64), nullable=False),
     sa.Column('primarygroup', sa.Integer(), nullable=False),
-    sa.ForeignKeyConstraint(['primarygroup'], ['group.unixid'], ),
+    sa.ForeignKeyConstraint(['primarygroup'], ['group.gidnumber'], ),
     sa.PrimaryKeyConstraint('id'),
-    sa.UniqueConstraint('unixid')
+    sa.UniqueConstraint('uidnumber')
     )
     op.create_index(op.f('ix_user_mail'), 'user', ['mail'], unique=True)
     op.create_index(op.f('ix_user_username'), 'user', ['username'], unique=True)
     op.create_table('othergroups_users',
     sa.Column('user_id', sa.Integer(), nullable=True),
     sa.Column('group_id', sa.Integer(), nullable=True),
-    sa.ForeignKeyConstraint(['group_id'], ['group.unixid'], ),
-    sa.ForeignKeyConstraint(['user_id'], ['user.unixid'], )
+    sa.ForeignKeyConstraint(['group_id'], ['group.gidnumber'], ),
+    sa.ForeignKeyConstraint(['user_id'], ['user.gidnumber'], )
     )
     # ### end Alembic commands ###
 


### PR DESCRIPTION
Hey Nils,

since glauth v2.0.0 complains about unixid being deprecated I replaced it with uidnumber and gidnumber accordingly.

To be consistent, I also changed the db column names in the group and user table.
So if you have an existing setup, you need to rename the sqlite columns using dbeaver for example.