### PR TITLE
add listening ip and port

### DIFF
--- a/boot.sh
+++ b/boot.sh
@@ -2,4 +2,4 @@
 source venv/bin/activate
 flask db upgrade
 flask createdbdata
-exec gunicorn -b :5000 --access-logfile - --error-logfile - ldap:app
+exec gunicorn -b ${LISTEN_IP:-0.0.0.0}:${LISTEN_PORT:-5000} --access-logfile - --error-logfile - ldap:app


### PR DESCRIPTION
Allows ip and port to be set from environment variable

- ip is set via env `LISTEN_IP`
- port is set via env `LISTEN_PORT`