### PR TITLE
Encrypt passwords using bcrypt, keep sha256 for backwards compatibility

### DIFF
--- a/app/glauth.py
+++ b/app/glauth.py
@@ -51,7 +51,10 @@ def create_glauth_config():
             new_config += "  mail = \"{}\"\n".format(user.mail)
         new_config += "  uidnumber = {}\n".format(user.unixid)
         new_config += "  primarygroup = {}\n".format(user.primarygroup)
-        new_config += "  passsha256 = \"{}\"\n".format(user.password_hash)
+        if not user.password_hash.startswith('$'): # SHA256 hashes were stored like this
+            new_config += "  passsha256 = \"{}\"\n".format(user.password_hash)
+        else: # bcrypt hashes have to be put into the config in hex representation
+            new_config += "  passbcrypt = \"{}\"\n".format(user.password_hash.encode("utf-8").hex())
         if len(user.othergroups) > 0:
             new_config += "  otherGroups = [ {} ]\n".format(",".join(str(group.unixid) for group in user.othergroups))
         if not user.is_active:

--- a/config.py
+++ b/config.py
@@ -1,10 +1,16 @@
 import os
 basedir = os.path.abspath(os.path.dirname(__file__))
 
+def optional_str_to_int(s):
+    if s is None: return None
+    return int(s)
+
+
 class Config(object):
     APPNAME = os.environ.get('APPNAME') or 'Glauth UI'
     ORGANISATION = os.environ.get('ORGANISATION') or 'Glauth UI - Team'
     SECRET_KEY = os.environ.get('SECRET_KEY') or 'you-will-never-guess'
+    BCRYPT_ROUNDS = optional_str_to_int(os.environ.get('BCRYPT_ROUNDS')) or 14
     ADMIN_GROUP = os.environ.get('ADMIN_GROUP') or 'glauth_admin'
 
     # MAIL Config
@@ -26,3 +32,4 @@ class Config(object):
     
     # FLASK ADMIN STUFF
     FLASK_ADMIN_FLUID_LAYOUT = False
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ python-dotenv==0.19.2
 SQLAlchemy==1.4.29
 Werkzeug==2.0.2
 WTForms==3.0.1
+passlib==1.7.4


### PR DESCRIPTION
The number of rounds can be specified by BCRYPT_ROUNDS environment variable. The default value is 14, as it takes 600 ms on my machine. As we currently only support bcrypt and plain sha256 hashes, we can distinguish them by the leading '$' of bcrypt hashes. Upgrading hashes on login is not yet implemented.